### PR TITLE
Correcting some audio-id mixups and updating audio-ids

### DIFF
--- a/yaml/10000309.yaml
+++ b/yaml/10000309.yaml
@@ -27,8 +27,3 @@ data:
     size: 34056573
     tracks: 6
     confidence: 0
-  - audio-id: 1691659153
-    hash: 87e064297f2d21fa6914d6b1c54224c2ead46cc2
-    size: 24702463
-    tracks: 6
-    confidence: 1

--- a/yaml/10000696.yaml
+++ b/yaml/10000696.yaml
@@ -16,4 +16,9 @@ data:
   shop-id: 3393ed18-f649-44dc-b56d-96d4d582947d
   track-desc:
   - '– 28: Der kleine Wassermann'
-  ids: []
+  ids:
+  - audio-id: 1666797375
+    hash: 53abd2020b225a2f5b9008580435535ab7b72a00
+    size: 90871099
+    tracks: 28
+    confidence: 0

--- a/yaml/10000909.yaml
+++ b/yaml/10000909.yaml
@@ -24,6 +24,6 @@ data:
   ids:
   - audio-id: 1691659153
     hash: 87e064297f2d21fa6914d6b1c54224c2ead46cc2
-    size: 0
-    tracks: 0
+    size: 24702463
+    tracks: 6
     confidence: 0

--- a/yaml/10001377.yaml
+++ b/yaml/10001377.yaml
@@ -24,4 +24,9 @@ data:
   - Hans im Glück
   - So kam Hans …
   - Outro
-  ids: []
+  ids:
+  - audio-id: 1686730242
+    hash: 9cb714eddcf486a134c4171842f936a12b0a5ea5
+    size: 49996064
+    tracks: 9
+    confidence: 0

--- a/yaml/10001378.yaml
+++ b/yaml/10001378.yaml
@@ -21,4 +21,9 @@ data:
   - 'Kapitel 04: Schneewittchen und die sieben Zwerge'
   - 'Kapitel 05: Schneewittchen und die sieben Zwerge'
   - 'Kapitel 06: Schneewittchen und die sieben Zwerge'
-  ids: []
+  ids:
+  - audio-id: 1699484451
+    hash: 6af72ddf5a4ac66bfaf6a0be222b3b0fec5c0af0
+    size: 41309924
+    tracks: 6
+    confidence: 0

--- a/yaml/10001473.yaml
+++ b/yaml/10001473.yaml
@@ -26,4 +26,9 @@ data:
   - Keine Angst, Leo!
   - In geheimer Mission
   - Leo und Ellli haben Streit
-  ids: []
+  ids:
+  - audio-id: 1679495635
+    hash: 880521ee967e5972d81aef1c9fa6e700f234464c
+    size: 41030370
+    tracks: 11
+    confidence: 0

--- a/yaml/10001484.yaml
+++ b/yaml/10001484.yaml
@@ -25,4 +25,9 @@ data:
   - Schneeweißchen und Rosenrot
   - Als sie nahe genug …
   - Outro
-  ids: []
+  ids:
+  - audio-id: 1688461411
+    hash: 58f75107c1f9279c37e0f61f505118569b685887
+    size: 55252550
+    tracks: 10
+    confidence: 0

--- a/yaml/10001675.yaml
+++ b/yaml/10001675.yaml
@@ -32,4 +32,9 @@ data:
   - Die dicken Jungs (Karaoke Version)
   - Wiedersehn (Karaoke Version)
   - Outro und Hidden Furz (Karaoke Version)
-  ids: []
+  ids:
+  - audio-id: 1679502178
+    hash: dd5c194107980f71abbef65a5827f5a71608486c
+    size: 38085201
+    tracks: 17
+    confidence: 0

--- a/yaml/10001693.yaml
+++ b/yaml/10001693.yaml
@@ -35,8 +35,3 @@ data:
     size: 30526872
     tracks: 14
     confidence: 1
-  - audio-id: 1666797375
-    hash: 53abd2020b225a2f5b9008580435535ab7b72a00
-    size: 0
-    tracks: 0
-    confidence: 0

--- a/yaml/10001889.yaml
+++ b/yaml/10001889.yaml
@@ -15,9 +15,4 @@ data:
   web: https://tonies.com/de-de///
   shop-id: db791279-cfba-47c0-8967-d44aa7199724
   track-desc: []
-  ids:
-  - audio-id: 1679502182
-    hash: b7e64b4d8e4d526b6c54dbf646e6c9c7b5019285
-    size: 47673783
-    tracks: 22
-    confidence: 1
+  ids: []

--- a/yaml/10001898.yaml
+++ b/yaml/10001898.yaml
@@ -36,4 +36,9 @@ data:
   - Die große Reise (Sabine, willst du mit mir fahren?)
   - Mein Lieblingsland, mein Lieblingsland
   - Töff, töff, töff, die Eisenbahn
-  ids: []
+  ids:
+  - audio-id: 1679502182
+    hash: b7e64b4d8e4d526b6c54dbf646e6c9c7b5019285
+    size: 47673783
+    tracks: 22
+    confidence: 0

--- a/yaml/10001991.yaml
+++ b/yaml/10001991.yaml
@@ -20,4 +20,9 @@ data:
   - Tom Lässt Sich Treiben
   - Der Doppelte Elvis
   - Der Rekordbär
-  ids: []
+  ids:
+  - audio-id: 1696593722
+    hash: 9a362ba6a022b22810f9530856a5d8ad0ac9a89c
+    size: 45660068
+    tracks: 5
+    confidence: 0

--- a/yaml/10001996.yaml
+++ b/yaml/10001996.yaml
@@ -21,4 +21,9 @@ data:
   - Alle für einen - einer für alle
   - Besuch aus dem All
   - Bälle für alle Fälle
-  ids: []
+  ids:
+  - audio-id: 1698970270
+    hash: c90e2f14f3fbbbaf71fcea1e0f4f6d12c43a6de6
+    size: 37747474
+    tracks: 6
+    confidence: 0

--- a/yaml/10001997.yaml
+++ b/yaml/10001997.yaml
@@ -16,4 +16,9 @@ data:
   shop-id: 2d3a9c5d-b3af-4318-9768-8e1bc7ce4173
   track-desc:
   - Mami spielt verrückt
-  ids: []
+  ids:
+  - audio-id: 1685704703
+    hash: 84d173743c1eb7979024c9eb1b4c50a51cd9b30a
+    size: 34145199
+    tracks: 1
+    confidence: 0

--- a/yaml/10002010.yaml
+++ b/yaml/10002010.yaml
@@ -33,4 +33,9 @@ data:
   - Lassie - Freunde fürs Leben - Teil 2
   - Lassie - Freunde fürs Leben - Teil 2
   - Lassie - Freunde fürs Leben - Teil 2
-  ids: []
+  ids:
+  - audio-id: 1698970295
+    hash: 4d73ba935df2afeb1dd0ea4ebd2d19fd11dbf5ab
+    size: 37230126
+    tracks: 18
+    confidence: 0

--- a/yaml/11000184.yaml
+++ b/yaml/11000184.yaml
@@ -22,4 +22,9 @@ data:
   - Das Fuchsmobil 2
   - Gemeinsam Statt Einsam 1
   - Gemeinsam Statt Einsam 2
-  ids: []
+  ids:
+  - audio-id: 1696971165
+    hash: 08cfcc8e82d007250ad3a7131a08b8ce0d5e70b7
+    size: 41027456
+    tracks: 7
+    confidence: 0

--- a/yaml/11000247.yaml
+++ b/yaml/11000247.yaml
@@ -25,3 +25,8 @@ data:
     size: 0
     tracks: 0
     confidence: 0
+  - audio-id: 1689923167
+    hash: a9f6394d9c4a620915332fda25f97b4197cbe86b
+    size: 38457853
+    tracks: 16
+    confidence: 0

--- a/yaml/11000291.yaml
+++ b/yaml/11000291.yaml
@@ -23,4 +23,9 @@ data:
   - Mit kleiner Fantasiereise geht's leichter
   - Es drückt am Bauch
   - Morgen... oder übermorgen... werde ich die Windel los!
-  ids: []
+  ids:
+  - audio-id: 1696576464
+    hash: e3e75e534ef30a3585461f9782adef474536cbed
+    size: 37908843
+    tracks: 8
+    confidence: 0

--- a/yaml/11000430.yaml
+++ b/yaml/11000430.yaml
@@ -35,4 +35,9 @@ data:
   - Der Spukusaurus - Teil 3
   - Der Spukusaurus - Teil 4
   - Der Spukusaurus - Teil 5
-  ids: []
+  ids:
+  - audio-id: 1701031920
+    hash: 4e7c01522a4b4b269f1a7df9f600685cc551437f
+    size: 41595999
+    tracks: 20
+    confidence: 0

--- a/yaml/11000465.yaml
+++ b/yaml/11000465.yaml
@@ -25,4 +25,9 @@ data:
   - Chaos am Muttertag 2
   - Das nicht so spaßige Spaßhaus 1
   - Das nicht so spaßige Spaßhaus 2
-  ids: []
+  ids:
+  - audio-id: 1701031871
+    hash: 6e4f294628c256414f5e70db1b5f9957acb4c4f5
+    size: 39486836
+    tracks: 9
+    confidence: 0

--- a/yaml/11000466.yaml
+++ b/yaml/11000466.yaml
@@ -24,4 +24,9 @@ data:
   - Fehler im System! 2
   - Teste deine Superkraft! 1
   - Teste deine Superkraft! 2
-  ids: []
+  ids:
+  - audio-id: 1701031854
+    hash: 5bb549ce46dc0ba4822e187fd7a6684e5117e153
+    size: 40908580
+    tracks: 9
+    confidence: 0

--- a/yaml/2000002791.yaml
+++ b/yaml/2000002791.yaml
@@ -21,4 +21,9 @@ data:
   - Leo Lausemaus kann nicht verlieren
   - Leo Lausemaus auf zum Sport
   - Schlussmusik
-  ids: []
+  ids:
+  - audio-id: 1584742151
+    hash: 0e02090b51a273f61c4e1ece6436263cc2d5f319
+    size: 35612669
+    tracks: 29
+    confidence: 0


### PR DESCRIPTION
There were some audio-ids assigned to the incorrect Tonie IDs.
10000309 -> 10000909 (audio-id already existed with missing information, but was assigned to both tonies)
10001693 -> 10000696
10001889 -> 10001989

I also added some unknown audio-ids.

I did not check for any further duplicates/mixups.