### PR TITLE
Add audio ids

### DIFF
--- a/yaml/11000925.yaml
+++ b/yaml/11000925.yaml
@@ -23,4 +23,9 @@ data:
   - Der Tanz der Stunden aus der Oper La Gioconda (Amilcare Ponchielli)
   - 'Eine Nacht auf dem kahlen Berge (Modest Mussorgski, Arr: Nikolai Rimski-Korsakow)
     und Ave Maria (Franz Schubert)'
-  ids: []
+  ids:
+  - audio-id: 1678897164
+    hash: 1B6F6DE9E251BC783B70D24847A1BF4A58676917
+    size: 47106618
+    tracks: 7
+    confidence: 0

--- a/yaml/11000925.yaml
+++ b/yaml/11000925.yaml
@@ -25,7 +25,7 @@ data:
     und Ave Maria (Franz Schubert)'
   ids:
   - audio-id: 1678897164
-    hash: 1B6F6DE9E251BC783B70D24847A1BF4A58676917
+    hash: 1b6f6de9e251bc783b70d24847a1bf4a58676917
     size: 47106618
     tracks: 7
     confidence: 0

--- a/yaml/2000002240.yaml
+++ b/yaml/2000002240.yaml
@@ -7,7 +7,7 @@ data:
   release: 1617148800
   language: de-de
   category: audio-play
-  runtime: 3771
+  runtime: 3772
   age: 6
   origin: tunes
   image: https://cdn.tonies.de/o/images/1_5bd05fdcd1c98117e584b1d71cd9edb90cc3d4786bbff700b78ec717/3_~mdm18Q4H0cQYZvy/ich_einfach_unverbesserlich_ich_einfach_unve_530x530.jpg

--- a/yaml/2000002240.yaml
+++ b/yaml/2000002240.yaml
@@ -7,7 +7,7 @@ data:
   release: 1617148800
   language: de-de
   category: audio-play
-  runtime: 3772
+  runtime: 63
   age: 6
   origin: tunes
   image: https://cdn.tonies.de/o/images/1_5bd05fdcd1c98117e584b1d71cd9edb90cc3d4786bbff700b78ec717/3_~mdm18Q4H0cQYZvy/ich_einfach_unverbesserlich_ich_einfach_unve_530x530.jpg

--- a/yaml/2000002240.yaml
+++ b/yaml/2000002240.yaml
@@ -63,7 +63,7 @@ data:
   - Ich - Einfach unverbesserlich 2 - Teil 46
   ids:
   - audio-id: 1701248827
-    hash: 6310609D6522F4365D2771A1AB49CEABCD19A635
+    hash: 6310609d6522f4365d2771a1ab49ceabcd19a635
     size: 45631981
     tracks: 46
     confidence: 0

--- a/yaml/2000002240.yaml
+++ b/yaml/2000002240.yaml
@@ -7,7 +7,7 @@ data:
   release: 1617148800
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 3771
   age: 6
   origin: tunes
   image: https://cdn.tonies.de/o/images/1_5bd05fdcd1c98117e584b1d71cd9edb90cc3d4786bbff700b78ec717/3_~mdm18Q4H0cQYZvy/ich_einfach_unverbesserlich_ich_einfach_unve_530x530.jpg
@@ -61,4 +61,9 @@ data:
   - Ich - Einfach unverbesserlich 2 - Teil 44
   - Ich - Einfach unverbesserlich 2 - Teil 45
   - Ich - Einfach unverbesserlich 2 - Teil 46
-  ids: []
+  ids:
+  - audio-id: 1701248827
+    hash: 6310609D6522F4365D2771A1AB49CEABCD19A635
+    size: 45631981
+    tracks: 46
+    confidence: 0

--- a/yaml/2000002241.yaml
+++ b/yaml/2000002241.yaml
@@ -7,7 +7,7 @@ data:
   release: 1617148800
   language: de-de
   category: audio-play
-  runtime: 4238
+  runtime: 71
   age: 6
   origin: tunes
   image: https://cdn.tonies.de/o/images/1_f5640cd754f8e6e7354b308a9bba4d013bd2998cab0ab0258bbe00a5/3_~mdm18Q4H0cQYZvy/ich_einfach_unverbesserlich_ich_einfach_unve_530x530.jpg

--- a/yaml/2000002241.yaml
+++ b/yaml/2000002241.yaml
@@ -58,7 +58,7 @@ data:
   - Ich - Einfach unverbesserlich 3 - Teil 41
   ids:
   - audio-id: 1701247941
-    hash: 37184D483FC5AB35F6707FA61B36DD625282E45B
+    hash: 37184d483fc5ab35f6707fa61b36dd625282e45b
     size: 52223210
     tracks: 41
     confidence: 0

--- a/yaml/2000002241.yaml
+++ b/yaml/2000002241.yaml
@@ -7,7 +7,7 @@ data:
   release: 1617148800
   language: de-de
   category: audio-play
-  runtime: 4237
+  runtime: 4238
   age: 6
   origin: tunes
   image: https://cdn.tonies.de/o/images/1_f5640cd754f8e6e7354b308a9bba4d013bd2998cab0ab0258bbe00a5/3_~mdm18Q4H0cQYZvy/ich_einfach_unverbesserlich_ich_einfach_unve_530x530.jpg

--- a/yaml/2000002241.yaml
+++ b/yaml/2000002241.yaml
@@ -7,7 +7,7 @@ data:
   release: 1617148800
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4237
   age: 6
   origin: tunes
   image: https://cdn.tonies.de/o/images/1_f5640cd754f8e6e7354b308a9bba4d013bd2998cab0ab0258bbe00a5/3_~mdm18Q4H0cQYZvy/ich_einfach_unverbesserlich_ich_einfach_unve_530x530.jpg
@@ -56,4 +56,9 @@ data:
   - Ich - Einfach unverbesserlich 3 - Teil 39
   - Ich - Einfach unverbesserlich 3 - Teil 40
   - Ich - Einfach unverbesserlich 3 - Teil 41
-  ids: []
+  ids:
+  - audio-id: 1701247941
+    hash: 37184D483FC5AB35F6707FA61B36DD625282E45B
+    size: 52223210
+    tracks: 41
+    confidence: 0

--- a/yaml/2000003672.yaml
+++ b/yaml/2000003672.yaml
@@ -7,7 +7,7 @@ data:
   release: 1665014400
   language: de-de
   category: audio-book
-  runtime: 8550
+  runtime: 143
   age: 8
   origin: tunes
   image: https://cdn.tonies.de/o/images/a4d28bcba2e32e848f00d756d799d617a4583dea2ed903beb60d098c/3_yK7RbrCKm~bHCdSc/bitte_nicht_offnen_002_schleimig_530x530.jpg

--- a/yaml/2000003672.yaml
+++ b/yaml/2000003672.yaml
@@ -7,7 +7,7 @@ data:
   release: 1665014400
   language: de-de
   category: audio-book
-  runtime: 0
+  runtime: 8550
   age: 8
   origin: tunes
   image: https://cdn.tonies.de/o/images/a4d28bcba2e32e848f00d756d799d617a4583dea2ed903beb60d098c/3_yK7RbrCKm~bHCdSc/bitte_nicht_offnen_002_schleimig_530x530.jpg
@@ -62,4 +62,9 @@ data:
   - Kapitel 45
   - Kapitel 46
   - Kapitel 47
-  ids: []
+  ids:
+  - audio-id: 1701246288
+    hash: 0E633112492F6622BA7EAE8383AE805F19C19014
+    size: 92848763
+    tracks: 47
+    confidence: 0

--- a/yaml/2000003672.yaml
+++ b/yaml/2000003672.yaml
@@ -64,7 +64,7 @@ data:
   - Kapitel 47
   ids:
   - audio-id: 1701246288
-    hash: 0E633112492F6622BA7EAE8383AE805F19C19014
+    hash: 0e633112492f6622ba7eae8383ae805f19c19014
     size: 92848763
     tracks: 47
     confidence: 0

--- a/yaml/2000003673.yaml
+++ b/yaml/2000003673.yaml
@@ -7,7 +7,7 @@ data:
   release: 1665014400
   language: de-de
   category: audio-book
-  runtime: 8833
+  runtime: 147
   age: 8
   origin: tunes
   image: https://cdn.tonies.de/o/images/8d1f48c843775fdd3f15d4a0528a0cebd911b7f47afc18ed9778de6d/3_nPjK0qcGF_82rs.4/bitte_nicht_offnen_003_durstig_530x530.jpg

--- a/yaml/2000003673.yaml
+++ b/yaml/2000003673.yaml
@@ -7,7 +7,7 @@ data:
   release: 1665014400
   language: de-de
   category: audio-book
-  runtime: 0
+  runtime: 8833
   age: 8
   origin: tunes
   image: https://cdn.tonies.de/o/images/8d1f48c843775fdd3f15d4a0528a0cebd911b7f47afc18ed9778de6d/3_nPjK0qcGF_82rs.4/bitte_nicht_offnen_003_durstig_530x530.jpg
@@ -60,4 +60,9 @@ data:
   - Kapitel 43
   - Kapitel 44
   - Kapitel 45
-  ids: []
+  ids:
+  - audio-id: 1701240455
+    hash: EAC04CE2443E395B86E57D7D8C4B9259EBDD3D30
+    size: 98841207
+    tracks: 45
+    confidence: 0

--- a/yaml/2000003673.yaml
+++ b/yaml/2000003673.yaml
@@ -62,7 +62,7 @@ data:
   - Kapitel 45
   ids:
   - audio-id: 1701240455
-    hash: EAC04CE2443E395B86E57D7D8C4B9259EBDD3D30
+    hash: eac04ce2443e395b86e57d7d8c4b9259ebdd3d30
     size: 98841207
     tracks: 45
     confidence: 0

--- a/yaml/2000003674.yaml
+++ b/yaml/2000003674.yaml
@@ -58,7 +58,7 @@ data:
   - Kapitel 41
   ids:
   - audio-id: 1701248090
-    hash: E60096513FA2AEC1C6EB53817174D6D6961FA225
+    hash: e60096513fa2aec1c6eb53817174d6d6961fa225
     size: 102099398
     tracks: 41
     confidence: 0

--- a/yaml/2000003674.yaml
+++ b/yaml/2000003674.yaml
@@ -7,7 +7,7 @@ data:
   release: 1665014400
   language: de-de
   category: audio-book
-  runtime: 9528
+  runtime: 159
   age: 8
   origin: tunes
   image: https://cdn.tonies.de/o/images/e97f42eb50edf54b1d18a37feeafab01b2a285951dd3a89cd5e7729c/3_FJPPsQqjq3Vl8~Tz/bitte_nicht_offnen_004_feurig_530x530.jpg

--- a/yaml/2000003674.yaml
+++ b/yaml/2000003674.yaml
@@ -7,7 +7,7 @@ data:
   release: 1665014400
   language: de-de
   category: audio-book
-  runtime: 0
+  runtime: 9528
   age: 8
   origin: tunes
   image: https://cdn.tonies.de/o/images/e97f42eb50edf54b1d18a37feeafab01b2a285951dd3a89cd5e7729c/3_FJPPsQqjq3Vl8~Tz/bitte_nicht_offnen_004_feurig_530x530.jpg
@@ -56,4 +56,9 @@ data:
   - Kapitel 39
   - Kapitel 40
   - Kapitel 41
-  ids: []
+  ids:
+  - audio-id: 1701248090
+    hash: E60096513FA2AEC1C6EB53817174D6D6961FA225
+    size: 102099398
+    tracks: 41
+    confidence: 0

--- a/yaml/2000003675.yaml
+++ b/yaml/2000003675.yaml
@@ -7,7 +7,7 @@ data:
   release: 1665014400
   language: de-de
   category: audio-book
-  runtime: 9396
+  runtime: 157
   age: 8
   origin: tunes
   image: https://cdn.tonies.de/o/images/aa30215fe8c6ca1254e2af524dc53229e84bdb21fb73c7e3bdfbbd5f/3_tCdbpbDSq3DF1_rZ/bitte_nicht_offnen_005_magic_530x530.jpg

--- a/yaml/2000003675.yaml
+++ b/yaml/2000003675.yaml
@@ -75,7 +75,7 @@ data:
   - Kapitel 58
   ids:
   - audio-id: 1701244916
-    hash: EC4961E81DB47E76E61A30740F5DC268E3E78D19
+    hash: ec4961e81db47e76e61a30740f5dc268e3e78d19
     size: 101281049
     tracks: 58
     confidence: 0

--- a/yaml/2000003675.yaml
+++ b/yaml/2000003675.yaml
@@ -7,7 +7,7 @@ data:
   release: 1665014400
   language: de-de
   category: audio-book
-  runtime: 0
+  runtime: 9396
   age: 8
   origin: tunes
   image: https://cdn.tonies.de/o/images/aa30215fe8c6ca1254e2af524dc53229e84bdb21fb73c7e3bdfbbd5f/3_tCdbpbDSq3DF1_rZ/bitte_nicht_offnen_005_magic_530x530.jpg
@@ -73,4 +73,9 @@ data:
   - Kapitel 56
   - Kapitel 57
   - Kapitel 58
-  ids: []
+  ids:
+  - audio-id: 1701244916
+    hash: EC4961E81DB47E76E61A30740F5DC268E3E78D19
+    size: 101281049
+    tracks: 58
+    confidence: 0

--- a/yaml/2000003676.yaml
+++ b/yaml/2000003676.yaml
@@ -7,7 +7,7 @@ data:
   release: 1665014400
   language: de-de
   category: audio-book
-  runtime: 9474
+  runtime: 158
   age: 8
   origin: tunes
   image: https://cdn.tonies.de/o/images/897dc0778159a8064499e9347a63cc1a3faedee58684370afc959e9e/3_GvxVKLrgQ5nyxFnq/bitte_nicht_offnen_006_rostig_530x530.jpg

--- a/yaml/2000003676.yaml
+++ b/yaml/2000003676.yaml
@@ -61,7 +61,7 @@ data:
   - Kapitel 44
   ids:
   - audio-id: 1701240966
-    hash: 4F8CE00CD71B69036158D9233C54D4E945830D2E
+    hash: 4f8ce00cd71b69036158d9233c54d4e945830d2e
     size: 96138327
     tracks: 44
     confidence: 0

--- a/yaml/2000003676.yaml
+++ b/yaml/2000003676.yaml
@@ -7,7 +7,7 @@ data:
   release: 1665014400
   language: de-de
   category: audio-book
-  runtime: 0
+  runtime: 9474
   age: 8
   origin: tunes
   image: https://cdn.tonies.de/o/images/897dc0778159a8064499e9347a63cc1a3faedee58684370afc959e9e/3_GvxVKLrgQ5nyxFnq/bitte_nicht_offnen_006_rostig_530x530.jpg
@@ -59,4 +59,9 @@ data:
   - Kapitel 42
   - Kapitel 43
   - Kapitel 44
-  ids: []
+  ids:
+  - audio-id: 1701240966
+    hash: 4F8CE00CD71B69036158D9233C54D4E945830D2E
+    size: 96138327
+    tracks: 44
+    confidence: 0

--- a/yaml/2000003840.yaml
+++ b/yaml/2000003840.yaml
@@ -7,7 +7,7 @@ data:
   release: 1671062400
   language: de-de
   category: audio-play
-  runtime: 2308
+  runtime: 38
   age: 3
   origin: tunes
   image: https://cdn.tonies.de/o/images/1_c3de81cf6ca29849bfdf70dcb7a031e8e856ec77e1c65b1321b1a034/3_Q7hltdyy-s3_y7_0/das_kleine_wir_das_kleine_wir_in_der_schule_530x530.jpg

--- a/yaml/2000003840.yaml
+++ b/yaml/2000003840.yaml
@@ -29,7 +29,7 @@ data:
   - Kapitel 12
   ids:
   - audio-id: 1724328334
-    hash: 80364BD21093C481FFB84A82C647C1A9AEFC244D
+    hash: 80364bd21093c481ffb84a82c647c1a9aefc244d
     size: 29303316
     tracks: 12
     confidence: 0

--- a/yaml/2000003840.yaml
+++ b/yaml/2000003840.yaml
@@ -27,4 +27,9 @@ data:
   - Kapitel 10
   - Kapitel 11
   - Kapitel 12
-  ids: []
+  ids:
+  - audio-id: 1724328334
+    hash: 80364BD21093C481FFB84A82C647C1A9AEFC244D
+    size: 29303316
+    tracks: 12
+    confidence: 0

--- a/yaml/2000010581.yaml
+++ b/yaml/2000010581.yaml
@@ -56,7 +56,7 @@ data:
   - Kapitel 39
   ids:
   - audio-id: 1700659064
-    hash: 59A2F6B8D8119DDE1F27800162E5DF845F6A95D9
+    hash: 59a2f6b8d8119dde1f27800162e5df845f6a95d9
     size: 57683540
     tracks: 39
     confidence: 0

--- a/yaml/2000010581.yaml
+++ b/yaml/2000010581.yaml
@@ -7,7 +7,7 @@ data:
   release: 1700006400
   language: de-de
   category: audio-play
-  runtime: 4798
+  runtime: 80
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/329799f9221cdf9b0c74b82719ce5cd87368856cc959caf040dde0a9/3_CNCBrQtlWd9K8z0s/diary_of_a_wimpy_kid_014_gregs_tagebuch_folge_530x530.jpg

--- a/yaml/2000010581.yaml
+++ b/yaml/2000010581.yaml
@@ -7,7 +7,7 @@ data:
   release: 1700006400
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4798
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/329799f9221cdf9b0c74b82719ce5cd87368856cc959caf040dde0a9/3_CNCBrQtlWd9K8z0s/diary_of_a_wimpy_kid_014_gregs_tagebuch_folge_530x530.jpg
@@ -54,4 +54,9 @@ data:
   - Kapitel 37
   - Kapitel 38
   - Kapitel 39
-  ids: []
+  ids:
+  - audio-id: 1700659064
+    hash: 59A2F6B8D8119DDE1F27800162E5DF845F6A95D9
+    size: 57683540
+    tracks: 39
+    confidence: 0

--- a/yaml/2000010582.yaml
+++ b/yaml/2000010582.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4322
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/46b8dd4e01173d39cabe873adb291008d989fa5c00ecc651f1277c83/3_zsCqKMhfT0p8.yQr/greg_s_tagebuch_007_dumm_gelaufen_530x530.jpg
@@ -51,4 +51,9 @@ data:
   - Kapitel 34
   - Kapitel 35
   - Kapitel 36
-  ids: []
+  ids:
+  - audio-id: 1700659110
+    hash: 7CFB532C8A4AE58A2B6CA6CA45207A14517CC640
+    size: 52522865
+    tracks: 36
+    confidence: 0

--- a/yaml/2000010582.yaml
+++ b/yaml/2000010582.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 4322
+  runtime: 72
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/46b8dd4e01173d39cabe873adb291008d989fa5c00ecc651f1277c83/3_zsCqKMhfT0p8.yQr/greg_s_tagebuch_007_dumm_gelaufen_530x530.jpg

--- a/yaml/2000010582.yaml
+++ b/yaml/2000010582.yaml
@@ -53,7 +53,7 @@ data:
   - Kapitel 36
   ids:
   - audio-id: 1700659110
-    hash: 7CFB532C8A4AE58A2B6CA6CA45207A14517CC640
+    hash: 7cfb532c8a4ae58a2b6ca6ca45207a14517cc640
     size: 52522865
     tracks: 36
     confidence: 0

--- a/yaml/2000010583.yaml
+++ b/yaml/2000010583.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 4625
+  runtime: 77
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/fd7504b618a7b6ccf093782097ea8d7c7667b4490c45bd040e9f1a51/3_3lh.HQcsy~hYY0GB/greg_s_tagebuch_006_keine_panik_530x530.jpg

--- a/yaml/2000010583.yaml
+++ b/yaml/2000010583.yaml
@@ -55,7 +55,7 @@ data:
   - Kapitel 38
   ids:
   - audio-id: 1701246636
-    hash: 2B968C350DCB280C7B22F6C406BF764F3CD7FF50
+    hash: 2b968c350dcb280c7b22f6c406bf764f3cd7ff50
     size: 55399749
     tracks: 38
     confidence: 0

--- a/yaml/2000010583.yaml
+++ b/yaml/2000010583.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4625
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/fd7504b618a7b6ccf093782097ea8d7c7667b4490c45bd040e9f1a51/3_3lh.HQcsy~hYY0GB/greg_s_tagebuch_006_keine_panik_530x530.jpg
@@ -53,4 +53,9 @@ data:
   - Kapitel 36
   - Kapitel 37
   - Kapitel 38
-  ids: []
+  ids:
+  - audio-id: 1701246636
+    hash: 2B968C350DCB280C7B22F6C406BF764F3CD7FF50
+    size: 55399749
+    tracks: 38
+    confidence: 0

--- a/yaml/2000010584.yaml
+++ b/yaml/2000010584.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4505
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/39696ca64f15dfafe690ba4261173d0aa583a54a63cc4173b851af21/3_r3yjMM4Hx28_h0.n/greg_s_tagebuch_005_geht_s_noch_530x530.jpg
@@ -52,4 +52,9 @@ data:
   - Kapitel 35
   - Kapitel 36
   - Kapitel 37
-  ids: []
+  ids:
+  - audio-id: 1701242213
+    hash: E51D6D4C75C3442D60FC7C9315D0AD58F1DC823B
+    size: 53516241
+    tracks: 37
+    confidence: 0

--- a/yaml/2000010584.yaml
+++ b/yaml/2000010584.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 4505
+  runtime: 75
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/39696ca64f15dfafe690ba4261173d0aa583a54a63cc4173b851af21/3_r3yjMM4Hx28_h0.n/greg_s_tagebuch_005_geht_s_noch_530x530.jpg

--- a/yaml/2000010584.yaml
+++ b/yaml/2000010584.yaml
@@ -54,7 +54,7 @@ data:
   - Kapitel 37
   ids:
   - audio-id: 1701242213
-    hash: E51D6D4C75C3442D60FC7C9315D0AD58F1DC823B
+    hash: e51d6d4c75c3442d60fc7c9315d0ad58f1dc823b
     size: 53516241
     tracks: 37
     confidence: 0

--- a/yaml/2000010585.yaml
+++ b/yaml/2000010585.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4617
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/01923755e0a915b872bc80fcb87f5843d434902a147dc3d8ba5128d1/3_cpvf25cVC9JQW-9Q/greg_s_tagebuch_004_ich_war_s_nicht_530x530.jpg
@@ -53,4 +53,9 @@ data:
   - Kapitel 36
   - Kapitel 37
   - Kapitel 38
-  ids: []
+  ids:
+  - audio-id: 1700658905
+    hash: DDF8709F2273F8BD6FF3F8A21B85708D2E6599A6
+    size: 55814980
+    tracks: 38
+    confidence: 0

--- a/yaml/2000010585.yaml
+++ b/yaml/2000010585.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 4617
+  runtime: 77
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/01923755e0a915b872bc80fcb87f5843d434902a147dc3d8ba5128d1/3_cpvf25cVC9JQW-9Q/greg_s_tagebuch_004_ich_war_s_nicht_530x530.jpg

--- a/yaml/2000010585.yaml
+++ b/yaml/2000010585.yaml
@@ -55,7 +55,7 @@ data:
   - Kapitel 38
   ids:
   - audio-id: 1700658905
-    hash: DDF8709F2273F8BD6FF3F8A21B85708D2E6599A6
+    hash: ddf8709f2273f8bd6ff3f8a21b85708d2e6599a6
     size: 55814980
     tracks: 38
     confidence: 0

--- a/yaml/2000010586.yaml
+++ b/yaml/2000010586.yaml
@@ -56,7 +56,7 @@ data:
   - Kapitel 39
   ids:
   - audio-id: 1700659093
-    hash: 7AC35AEE54893E0CE2C6FC34D27243712643FB95
+    hash: 7ac35aee54893e0ce2c6fc34d27243712643fb95
     size: 55859731
     tracks: 39
     confidence: 0

--- a/yaml/2000010586.yaml
+++ b/yaml/2000010586.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4691
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/17f8ceccca84fd61f8f954a2cc01a0554f847f81a96d89f1dbf480f6/3_nmddpJBcV7m8l047/greg_s_tagebuch_003_jetzt_reicht_s_530x530.jpg
@@ -54,4 +54,9 @@ data:
   - Kapitel 37
   - Kapitel 38
   - Kapitel 39
-  ids: []
+  ids:
+  - audio-id: 1700659093
+    hash: 7AC35AEE54893E0CE2C6FC34D27243712643FB95
+    size: 55859731
+    tracks: 39
+    confidence: 0

--- a/yaml/2000010586.yaml
+++ b/yaml/2000010586.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 4691
+  runtime: 78
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/17f8ceccca84fd61f8f954a2cc01a0554f847f81a96d89f1dbf480f6/3_nmddpJBcV7m8l047/greg_s_tagebuch_003_jetzt_reicht_s_530x530.jpg

--- a/yaml/2000010587.yaml
+++ b/yaml/2000010587.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 4565
+  runtime: 76
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/eea7ebfcf1c59673991ace6ca7a37e0624c365d0b6c81bc1c689f1a6/3_fPlYQFTWzdknwbPm/greg_s_tagebuch_002_gibt_s_probleme_530x530.jpg

--- a/yaml/2000010587.yaml
+++ b/yaml/2000010587.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4565
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/eea7ebfcf1c59673991ace6ca7a37e0624c365d0b6c81bc1c689f1a6/3_fPlYQFTWzdknwbPm/greg_s_tagebuch_002_gibt_s_probleme_530x530.jpg
@@ -53,4 +53,9 @@ data:
   - Kapitel 36
   - Kapitel 37
   - Kapitel 38
-  ids: []
+  ids:
+  - audio-id: 1701243300
+    hash: 32D2DB5B03E5CBFEAD3ECF672AC517EAFEAB7A60
+    size: 53683666
+    tracks: 38
+    confidence: 0

--- a/yaml/2000010587.yaml
+++ b/yaml/2000010587.yaml
@@ -55,7 +55,7 @@ data:
   - Kapitel 38
   ids:
   - audio-id: 1701243300
-    hash: 32D2DB5B03E5CBFEAD3ECF672AC517EAFEAB7A60
+    hash: 32d2db5b03e5cbfead3ecf672ac517eafeab7a60
     size: 53683666
     tracks: 38
     confidence: 0

--- a/yaml/2000010589.yaml
+++ b/yaml/2000010589.yaml
@@ -34,7 +34,7 @@ data:
   - Kapitel 17
   ids:
   - audio-id: 1700658987
-    hash: B0534596B3E633F94A185F03F897EA8A1E37B413
+    hash: b0534596b3e633f94a185f03f897ea8a1e37b413
     size: 50113206
     tracks: 17
     confidence: 0

--- a/yaml/2000010589.yaml
+++ b/yaml/2000010589.yaml
@@ -7,7 +7,7 @@ data:
   release: 1700006400
   language: de-de
   category: audio-play
-  runtime: 4053
+  runtime: 68
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/0c7dec68afd581264b606c2ab714f23b58bea22ef2ffe433a6b7750e/3_ht2Hnn3cF-FvljKt/diary_of_a_wimpy_kid_017_gregs_tagebuch_folge_530x530.jpg

--- a/yaml/2000010589.yaml
+++ b/yaml/2000010589.yaml
@@ -7,7 +7,7 @@ data:
   release: 1700006400
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4053
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/0c7dec68afd581264b606c2ab714f23b58bea22ef2ffe433a6b7750e/3_ht2Hnn3cF-FvljKt/diary_of_a_wimpy_kid_017_gregs_tagebuch_folge_530x530.jpg
@@ -32,4 +32,9 @@ data:
   - Kapitel 15
   - Kapitel 16
   - Kapitel 17
-  ids: []
+  ids:
+  - audio-id: 1700658987
+    hash: B0534596B3E633F94A185F03F897EA8A1E37B413
+    size: 50113206
+    tracks: 17
+    confidence: 0

--- a/yaml/2000010590.yaml
+++ b/yaml/2000010590.yaml
@@ -7,7 +7,7 @@ data:
   release: 1700006400
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4573
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/664c545d545204bf54a23c94bd2ad45b47126009e6f4fd935c1fb4c5/3_pkL9ZYmk2r-gb.1J/diary_of_a_wimpy_kid_016_gregs_tagebuch_folge_530x530.jpg
@@ -53,4 +53,9 @@ data:
   - Kapitel 36
   - Kapitel 37
   - Kapitel 38
-  ids: []
+  ids:
+  - audio-id: 1701245751
+    hash: 9048B679412F2EE3DFB94283FD5ACA22039C9504
+    size: 58221788
+    tracks: 38
+    confidence: 0

--- a/yaml/2000010590.yaml
+++ b/yaml/2000010590.yaml
@@ -55,7 +55,7 @@ data:
   - Kapitel 38
   ids:
   - audio-id: 1701245751
-    hash: 9048B679412F2EE3DFB94283FD5ACA22039C9504
+    hash: 9048b679412f2ee3dfb94283fd5aca22039c9504
     size: 58221788
     tracks: 38
     confidence: 0

--- a/yaml/2000010590.yaml
+++ b/yaml/2000010590.yaml
@@ -7,7 +7,7 @@ data:
   release: 1700006400
   language: de-de
   category: audio-play
-  runtime: 4573
+  runtime: 76
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/664c545d545204bf54a23c94bd2ad45b47126009e6f4fd935c1fb4c5/3_pkL9ZYmk2r-gb.1J/diary_of_a_wimpy_kid_016_gregs_tagebuch_folge_530x530.jpg

--- a/yaml/2000010591.yaml
+++ b/yaml/2000010591.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 4786
+  runtime: 80
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/46e4f050fb7f466d71988c485fd2e347fbef8bfa1377818f4403db52/3_t79kZvnJszhLJPRT/greg_s_tagebuch_013_gregs_tagebuch_folge_13___530x530.jpg

--- a/yaml/2000010591.yaml
+++ b/yaml/2000010591.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4786
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/46e4f050fb7f466d71988c485fd2e347fbef8bfa1377818f4403db52/3_t79kZvnJszhLJPRT/greg_s_tagebuch_013_gregs_tagebuch_folge_13___530x530.jpg
@@ -54,4 +54,9 @@ data:
   - Kapitel 37
   - Kapitel 38
   - Kapitel 39
-  ids: []
+  ids:
+  - audio-id: 1701244304
+    hash: 2FD228FFA0E94BBF3D5AC461097AE30FDCB99BD8
+    size: 57331378
+    tracks: 39
+    confidence: 0

--- a/yaml/2000010591.yaml
+++ b/yaml/2000010591.yaml
@@ -56,7 +56,7 @@ data:
   - Kapitel 39
   ids:
   - audio-id: 1701244304
-    hash: 2FD228FFA0E94BBF3D5AC461097AE30FDCB99BD8
+    hash: 2fd228ffa0e94bbf3d5ac461097ae30fdcb99bd8
     size: 57331378
     tracks: 39
     confidence: 0

--- a/yaml/2000010592.yaml
+++ b/yaml/2000010592.yaml
@@ -7,7 +7,7 @@ data:
   release: 1700006400
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4538
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/d9a285c0594e451772a0caaef4832acee4e0527b9d631da9f3210081/3_p7bqJkspmKNJ8wdn/diary_of_a_wimpy_kid_015_gregs_tagebuch_folge_530x530.jpg
@@ -52,4 +52,9 @@ data:
   - Kapitel 35
   - Kapitel 36
   - Kapitel 37
-  ids: []
+  ids:
+  - audio-id: 1701242225
+    hash: 7FCD6588BAC6E125D2E4FEA13B8E0FCC9A28D097
+    size: 56554945
+    tracks: 37
+    confidence: 0

--- a/yaml/2000010592.yaml
+++ b/yaml/2000010592.yaml
@@ -7,7 +7,7 @@ data:
   release: 1700006400
   language: de-de
   category: audio-play
-  runtime: 4538
+  runtime: 76
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/d9a285c0594e451772a0caaef4832acee4e0527b9d631da9f3210081/3_p7bqJkspmKNJ8wdn/diary_of_a_wimpy_kid_015_gregs_tagebuch_folge_530x530.jpg

--- a/yaml/2000010592.yaml
+++ b/yaml/2000010592.yaml
@@ -54,7 +54,7 @@ data:
   - Kapitel 37
   ids:
   - audio-id: 1701242225
-    hash: 7FCD6588BAC6E125D2E4FEA13B8E0FCC9A28D097
+    hash: 7fcd6588bac6e125d2e4fea13b8e0fcc9a28d097
     size: 56554945
     tracks: 37
     confidence: 0

--- a/yaml/2000010593.yaml
+++ b/yaml/2000010593.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4734
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/676939520de14cf6233a71dd22b3ca9b6b181fa1ac370761cd12b642/3_2GPHq2ZjQsYbw-yf/greg_s_tagebuch_012_gregs_tagebuch_folge_12___530x530.jpg
@@ -54,4 +54,9 @@ data:
   - Kapitel 37
   - Kapitel 38
   - Kapitel 39
-  ids: []
+  ids:
+  - audio-id: 1701240914
+    hash: 5419FDD34B196271C60281AE4468AD21F8880830
+    size: 59498489
+    tracks: 39
+    confidence: 0

--- a/yaml/2000010593.yaml
+++ b/yaml/2000010593.yaml
@@ -56,7 +56,7 @@ data:
   - Kapitel 39
   ids:
   - audio-id: 1701240914
-    hash: 5419FDD34B196271C60281AE4468AD21F8880830
+    hash: 5419fdd34b196271c60281ae4468ad21f8880830
     size: 59498489
     tracks: 39
     confidence: 0

--- a/yaml/2000010593.yaml
+++ b/yaml/2000010593.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 4734
+  runtime: 79
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/676939520de14cf6233a71dd22b3ca9b6b181fa1ac370761cd12b642/3_2GPHq2ZjQsYbw-yf/greg_s_tagebuch_012_gregs_tagebuch_folge_12___530x530.jpg

--- a/yaml/2000010594.yaml
+++ b/yaml/2000010594.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 3401
+  runtime: 57
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/dcf1b14ca792a5dca52deb09b21d006eb5a30facb532c889fee5e205/3_SxP2Gpc3.rffvTB5/greg_s_tagebuch_011_gregs_tagebuch_folge_11___530x530.jpg

--- a/yaml/2000010594.yaml
+++ b/yaml/2000010594.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 3401
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/dcf1b14ca792a5dca52deb09b21d006eb5a30facb532c889fee5e205/3_SxP2Gpc3.rffvTB5/greg_s_tagebuch_011_gregs_tagebuch_folge_11___530x530.jpg
@@ -43,4 +43,9 @@ data:
   - Kapitel 26
   - Kapitel 27
   - Kapitel 28
-  ids: []
+  ids:
+  - audio-id: 1700659130
+    hash: 3EE8B19109887C90E5314C1D2905F3312EF4612E
+    size: 41096244
+    tracks: 28
+    confidence: 0

--- a/yaml/2000010594.yaml
+++ b/yaml/2000010594.yaml
@@ -45,7 +45,7 @@ data:
   - Kapitel 28
   ids:
   - audio-id: 1700659130
-    hash: 3EE8B19109887C90E5314C1D2905F3312EF4612E
+    hash: 3ee8b19109887c90e5314c1d2905f3312ef4612e
     size: 41096244
     tracks: 28
     confidence: 0

--- a/yaml/2000010595.yaml
+++ b/yaml/2000010595.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4248
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/608bbb07560ebecd0c8cbb46880b0ec789eca4b486e5b5f9c729354d/3_jr7DmBYylv~qwNry/greg_s_tagebuch_010_gregs_tagebuch_folge_10___530x530.jpg
@@ -50,4 +50,9 @@ data:
   - Kapitel 33
   - Kapitel 34
   - Kapitel 35
-  ids: []
+  ids:
+  - audio-id: 1701244350
+    hash: A2D574B85BB7091CB39ADFA134F29BEADBA4F7A3
+    size: 50195572
+    tracks: 35
+    confidence: 0

--- a/yaml/2000010595.yaml
+++ b/yaml/2000010595.yaml
@@ -52,7 +52,7 @@ data:
   - Kapitel 35
   ids:
   - audio-id: 1701244350
-    hash: A2D574B85BB7091CB39ADFA134F29BEADBA4F7A3
+    hash: a2d574b85bb7091cb39adfa134f29beadba4f7a3
     size: 50195572
     tracks: 35
     confidence: 0

--- a/yaml/2000010595.yaml
+++ b/yaml/2000010595.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 4248
+  runtime: 71
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/608bbb07560ebecd0c8cbb46880b0ec789eca4b486e5b5f9c729354d/3_jr7DmBYylv~qwNry/greg_s_tagebuch_010_gregs_tagebuch_folge_10___530x530.jpg

--- a/yaml/2000010596.yaml
+++ b/yaml/2000010596.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 4618
+  runtime: 77
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/33cbea100927bfc04facf30cce17ab560588f5ac3dbe647040b28a55/3__Xn55jtv90qNSYl~/greg_s_tagebuch_009_bose_falle_530x530.jpg

--- a/yaml/2000010596.yaml
+++ b/yaml/2000010596.yaml
@@ -55,7 +55,7 @@ data:
   - Kapitel 38
   ids:
   - audio-id: 1701243748
-    hash: 7583922396E707B888EE9A6F2CF3A9FFB3E93072
+    hash: 7583922396e707b888ee9a6f2cf3a9ffb3e93072
     size: 55605426
     tracks: 38
     confidence: 0

--- a/yaml/2000010596.yaml
+++ b/yaml/2000010596.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4618
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/33cbea100927bfc04facf30cce17ab560588f5ac3dbe647040b28a55/3__Xn55jtv90qNSYl~/greg_s_tagebuch_009_bose_falle_530x530.jpg
@@ -53,4 +53,9 @@ data:
   - Kapitel 36
   - Kapitel 37
   - Kapitel 38
-  ids: []
+  ids:
+  - audio-id: 1701243748
+    hash: 7583922396E707B888EE9A6F2CF3A9FFB3E93072
+    size: 55605426
+    tracks: 38
+    confidence: 0

--- a/yaml/2000010597.yaml
+++ b/yaml/2000010597.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 4068
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/a2e4d5c676205a845e29b7950203229d85741be008ebc7581f9b7e0a/3_X2z~-l7QpLBRQwgJ/greg_s_tagebuch_008_echt_ubel_530x530.jpg
@@ -48,4 +48,9 @@ data:
   - Kapitel 31
   - Kapitel 32
   - Kapitel 33
-  ids: []
+  ids:
+  - audio-id: 1701248697
+    hash: 63D3C43E390CEE22C2B7FC6A76DDFAC9242FA63C
+    size: 48621822
+    tracks: 33
+    confidence: 0

--- a/yaml/2000010597.yaml
+++ b/yaml/2000010597.yaml
@@ -50,7 +50,7 @@ data:
   - Kapitel 33
   ids:
   - audio-id: 1701248697
-    hash: 63D3C43E390CEE22C2B7FC6A76DDFAC9242FA63C
+    hash: 63d3c43e390cee22c2b7fc6a76ddfac9242fa63c
     size: 48621822
     tracks: 33
     confidence: 0

--- a/yaml/2000010597.yaml
+++ b/yaml/2000010597.yaml
@@ -7,7 +7,7 @@ data:
   release: 1697587200
   language: de-de
   category: audio-play
-  runtime: 4068
+  runtime: 68
   age: 10
   origin: tunes
   image: https://cdn.tonies.de/o/images/a2e4d5c676205a845e29b7950203229d85741be008ebc7581f9b7e0a/3_X2z~-l7QpLBRQwgJ/greg_s_tagebuch_008_echt_ubel_530x530.jpg

--- a/yaml/2000010652.yaml
+++ b/yaml/2000010652.yaml
@@ -7,7 +7,7 @@ data:
   release: 1701216000
   language: de-de
   category: audio-play
-  runtime: 1429
+  runtime: 24
   age: 3
   origin: tunes
   image: https://cdn.tonies.de/o/images/1_45a5ae16e83cdaff13379775a744f73783a110de38d2e1007b5cd41a/3_CvDpvyQzC~lK6zbV/pummel_friends_003_der_weihnachtskuchen_530x530.jpg

--- a/yaml/2000010652.yaml
+++ b/yaml/2000010652.yaml
@@ -23,7 +23,7 @@ data:
   - Kapitel 06
   ids:
   - audio-id: 1701247110
-    hash: E2A42DCF21DDB7D0C07718318DA1D5D6FA00E6C3
+    hash: e2a42dcf21ddb7d0c07718318da1d5d6fa00e6c3
     size: 18058804
     tracks: 6
     confidence: 0

--- a/yaml/2000010652.yaml
+++ b/yaml/2000010652.yaml
@@ -7,7 +7,7 @@ data:
   release: 1701216000
   language: de-de
   category: audio-play
-  runtime: 0
+  runtime: 1429
   age: 3
   origin: tunes
   image: https://cdn.tonies.de/o/images/1_45a5ae16e83cdaff13379775a744f73783a110de38d2e1007b5cd41a/3_CvDpvyQzC~lK6zbV/pummel_friends_003_der_weihnachtskuchen_530x530.jpg
@@ -21,4 +21,9 @@ data:
   - Kapitel 04
   - Kapitel 05
   - Kapitel 06
-  ids: []
+  ids:
+  - audio-id: 1701247110
+    hash: E2A42DCF21DDB7D0C07718318DA1D5D6FA00E6C3
+    size: 18058804
+    tracks: 6
+    confidence: 0


### PR DESCRIPTION
# Updated Audio-IDs #
[2000003840]
Audio-Content
"Das kleine WIR - Das kleine WIR in der Schule"
assignable-to: same-series
tested with: 10000906

[2000010652]
Audio-Content
"Pummel & Friends - Der Weihnachtskuchen"
assignable-to: same-series;creative-tonie
tested with: 10002135;creative-tonie

[2000002240]
Audio-Content
"Ich - einfach unverbesserlich - Ich - Einfach unverbesserlich 2 (Das Original-Hörspiel zum Kinofilm)"
assignable-to: same-series
tested with: 01-0059

[2000002241]
Audio-Content
"Ich - einfach unverbesserlich - Ich - Einfach unverbesserlich 3 (Das Original-Hörspiel zum Kinofilm)"
assignable-to: same-series
tested with: 01-0059

[2000003672]
Audio-Content
"Bitte nicht öffnen - Schleimig!"
assignable-to: same-series
tested with: 10001212

[2000003673]
Audio-Content
"Bitte nicht öffnen - Durstig!"
assignable-to: same-series
tested with: 10001212

[2000003674]
Audio-Content
"Bitte nicht öffnen - Feurig!"
assignable-to: same-series
tested with: 10001212

[2000003675]
Audio-Content
"Bitte nicht öffnen - Magic!"
assignable-to: same-series
tested with: 10001212

[2000003676]
Audio-Content
"Bitte nicht öffnen - Rostig!"
assignable-to: same-series
tested with: 10001212

[2000010587]
Audio-Content
"Greg's Tagebuch - Gibt's Probleme?" (Teil 2)
assignable-to: same-series
tested with: 10000256

[2000010586]
Audio-Content
"Greg's Tagebuch - Jetzt reicht's!" (Teil 3)
assignable-to: same-series
tested with: 10000256

[2000010585]
Audio-Content
"Greg's Tagebuch - Ich war's nicht!" (Teil 4)
assignable-to: same-series
tested with: 10000256

[2000010584]
Audio-Content
"Greg's Tagebuch - Geht's noch?" (Teil 5)
assignable-to: same-series
tested with: 10000256

[2000010583]
Audio-Content
"Greg's Tagebuch - Keine Panik!" (Teil 6)
assignable-to: same-series
tested with: 10000256

[2000010582]
Audio-Content
"Greg's Tagebuch - Dumm gelaufen!" (Teil 7)
assignable-to: same-series
tested with: 10000256

[2000010597]
Audio-Content
"Greg's Tagebuch - Echt übel!" (Teil 8)
assignable-to: same-series
tested with: 10000256

[2000010596]
Audio-Content
"Greg's Tagebuch - Böse Falle!" (Teil 9)
assignable-to: same-series
tested with: 10000256

[2000010595]
Audio-Content
"Greg's Tagebuch - Gregs Tagebuch, Folge 10: So ein Mist!"
assignable-to: same-series
tested with: 10000256

[2000010594]
Audio-Content
"Greg's Tagebuch - Gregs Tagebuch, Folge 11: Alles Käse!"
assignable-to: same-series
tested with: 10000256

[2000010593]
Audio-Content
"Greg's Tagebuch - Gregs Tagebuch, Folge 12: Und tschüss!"
assignable-to: same-series
tested with: 10000256

[2000010591]
Audio-Content
"Greg's Tagebuch - Gregs Tagebuch, Folge 13: Eiskalt erwischt!"
assignable-to: same-series
tested with: 10000256

[2000010581]
Audio-Content
"Greg's Tagebuch - Gregs Tagebuch, Folge 14: Voll daneben!"
assignable-to: same-series
tested with: 10000256

[2000010592]
Audio-Content
"Greg's Tagebuch - Gregs Tagebuch, Folge 15: Halt mal die Luft an!"
assignable-to: same-series
tested with: 10000256

[2000010590]
Audio-Content
"Greg's Tagebuch - Gregs Tagebuch, Folge 16: Volltreffer!"
assignable-to: same-series
tested with: 10000256

[2000010589]
Audio-Content
"Greg's Tagebuch - Gregs Tagebuch, Folge 17: Voll aufgedreht!"
assignable-to: same-series
tested with: 10000256

[11000925]
Tonie
"Fantasia - Fantasia"

# Notes #
### [confidence] ###
Because I didn't know the logic you use to set the "confidence" value, I initially set it to 0.
I bought the audio content in these updates,
assigned each one individually to the corresponding Tonies,
loaded it onto the Toniebox and then read it out using Teddybench.
The audio IDs can therefore be considered verified.

### [runtime] ###
First I entered the "runtime" in seconds, because it was specified in seconds in the file "\yaml\2000003840.yaml".
Then I saw that the value in most other files is specified in minutes.
So I changed the "runtime" values ​​to rounded minutes.
(Although I don't know whether they should be rounded or whether the seconds should be left out)

### [assignable-to] ###
Otherwise, I think another field in the data set would be useful.
The Audio-Contents can only be assigned to certain Tonie figures.
The Tonie figure usually has to be from the same series in order
to be able to assign the content to the figure.
Some Audio-Contents can be assigned to the same series or to a creative Tonie.
By assigning audio content to a Tonie or creative Tonie,
the content on the Tonie is temporarily replaced.
No further content can be added to a creative Tonie as long as the audio content is assigned.

I therefore suggest adding an "assignable-to" data field to the data set.
You could then use "same-series" and/or "creative-tonie" as data.
Or directly the ID of the series or the article numbers of the Tonies,
although the article numbers would then always have to be updated when a new Tonie figure is added to the series.
```
#example 1
assignable-to:
- same-series
#example 2
assignable-to:
- same-series
- creative-tonie
or
#example 3
assignable-to:
- pummel-friends
- creative-tonie
or
#example 4
assignable-to:
- 10002135
- 1
```

like this or so:
```
article: '2000010652'
lock-data: false
data:
- series: Pummel & Friends
  series-id: pummel-friends
  assignable-to:
  - same-series
  - creative-tonie
  episode: Der Weihnachtskuchen
  ...
```