### PR TITLE
Remove wrong Audio-ID from '10001378'

### DIFF
--- a/yaml/10001378.yaml
+++ b/yaml/10001378.yaml
@@ -27,8 +27,3 @@ data:
     size: 41236847
     tracks: 6
     confidence: 2
-  - audio-id: 1699484451
-    hash: 6af72ddf5a4ac66bfaf6a0be222b3b0fec5c0af0
-    size: 41309924
-    tracks: 6
-    confidence: 1


### PR DESCRIPTION
'10001378 - Schneewittchen und die sieben Zwerge' contains a wrong Audio-ID.

'1699484451' is a dublicate in '10001378' an '11000462'

Correct one is '11000462': Spidey und seine Super-Freunde - Das Spidey Team & 3 weitere spannende Abenteuer, where it is already included.