### PR TITLE
Remove wrong Audio-ID from '11000526'.

### DIFF
--- a/yaml/11000526.yaml
+++ b/yaml/11000526.yaml
@@ -16,11 +16,6 @@ data:
   shop-id: '8124400664727'
   track-desc: []
   ids:
-  - audio-id: 1721192604
-    hash: cbeb617462fcc0e1aa9243e1c64423a654e9dd0c
-    size: 32304254
-    tracks: 2
-    confidence: 2
   - audio-id: 1701069621
     hash: a516f507921e1fa4d1505c6e935e973a51141416
     size: 32351751


### PR DESCRIPTION
'1721192604' is a dublicate in '11000526' and '11000282'
Correct one is '11000282':  Disney - Susi und Strolch → where it is already included.