### PR TITLE
Update 01-0098.yaml

### DIFF
--- a/yaml/01-0098.yaml
+++ b/yaml/01-0098.yaml
@@ -27,11 +27,6 @@ data:
   - Gute Nacht, kleine Eule!
   - Der Kuss von Papa hat gefehlt
   ids:
-  - audio-id: 1679496135
-    hash: 4c07ca6bec61d74c58a6f0891d2ec8c14d1556af
-    size: 0
-    tracks: 0
-    confidence: 0
   - audio-id: 1506516170
     hash: d734cbd53079912f5097f08c2d9853510534d0a8
     size: 25247408


### PR DESCRIPTION
If you put on the Toniebox the Tonie “Eule mit der Beule - Gute Nacht kleine Eule”, an incorrect picture is displayed. In the tonies.json, the audio ID 1679496135 can be found under model 01-0098. I don't think this is correct. The audio ID only belongs to 10001489.