### PR TITLE
- fix audio-id for KLE!NE EXPERTEN ... galoppieren mit Pferden

### DIFF
--- a/yaml/11000844.yaml
+++ b/yaml/11000844.yaml
@@ -25,8 +25,8 @@ data:
   - Der Reiterhof 3
   - Der Reiterhof 4
   ids:
-  - audio-id: 1736861405
-    hash: 1e68422e65b06c518e4eddfc28e63d8e6ff97509
-    size: 43739649
-    tracks: 10
+  - audio-id: 1737122301
+    hash: 1f4b250f29bb23c4ec62c57e77202361ecb28ee0
+    size: 43437798
+    tracks: 9
     confidence: 0


### PR DESCRIPTION
Fix because previous PR (https://github.com/toniebox-reverse-engineering/tonies-json/pull/128) used the same audio-id as KLE!NE EXPERTEN ... begleiten Elefanten

sorry 😕