### PR TITLE
Update 11001567.yaml  audio-id

### DIFF
--- a/yaml/11001567.yaml
+++ b/yaml/11001567.yaml
@@ -36,4 +36,9 @@ data:
   - 19. Henri Hofhund
   - 20. Der Bauer hat Geburtstag
   - 21. Jetzt schläft der ganze Bauernhof
-  ids: []
+  ids:
+  - audio-id: 1757762859
+    hash: 2d7b6b8e9bf3d4be7c7ca778d6fabb14462f8841
+    size: 104347633
+    tracks: 42
+    confidence: 0


### PR DESCRIPTION
Added audio ID.
The sound file repeats at around 63 minutes and 47 seconds, starting again from track 01 and replaying the track list.
This explains why there are 42 tracks listed in the TAF header.

<img width="742" height="513" alt="image" src="https://github.com/user-attachments/assets/985554de-c55e-46b0-9ef1-3c0d22612c12" />
