### PR TITLE
Removed wrong audio-id 1691657786 - 10001071.yaml

### DIFF
--- a/yaml/10001071.yaml
+++ b/yaml/10001071.yaml
@@ -16,11 +16,6 @@ data:
   shop-id: '7604933427351'
   track-desc: []
   ids:
-  - audio-id: 1691657786
-    hash: cc1e503ce9745cf2fb8334eb9d2650a9300c2a8f
-    size: 41313820
-    tracks: 6
-    confidence: 1
   - audio-id: 1649162686
     hash: d7b297677335dfff0be98d48c77578e1f5debf83
     size: 21846638


### PR DESCRIPTION
Removed 1691657786 since that's the de-de version which is also present in 10001368.yaml