### PR TITLE
Add audio-id 1771405208 for Schlummerwal (11000790)

### DIFF
--- a/yaml/11000790.yaml
+++ b/yaml/11000790.yaml
@@ -30,6 +30,11 @@ data:
   - Einschlafmelodien aus dem Ozean - 13
   - Einschlafmelodien aus dem Ozean - 14
   ids:
+  - audio-id: 1771405208
+    hash: 0742b814038bae2a8c35f6ff5015f5def53e6876
+    size: 111654857
+    tracks: 14
+    confidence: 0
   - audio-id: 1738846771
     hash: 634cb610605735d397bbb3dceddc57dcffdb4f7a
     size: 111765449


### PR DESCRIPTION
This PR adds a new audio-id for the Schlummerwal (Schlummerbande, article 11000790).

The existing entry contains audio-id 1738846771 (15 tracks). This new audio-id 1771405208 
was identified via TeddyCloud freshness check on 2026-02-18, suggesting Boxine re-encoded 
the content around that date. The new encoding results in 14 tracks instead of 15 — the 
original intro track appears to have been merged into the first chapter.

Verification:
- Audio-id and hash confirmed via TeddyCloud GUI (library modal)
- Cross-verified with TonieToolbox --info output
- Both methods returned identical values