### PR TITLE
Update image URL in 11000832.yaml

### DIFF
--- a/yaml/11000832.yaml
+++ b/yaml/11000832.yaml
@@ -10,7 +10,7 @@ data:
   runtime: 48
   age: 3
   origin: stock
-  image: https://images.cdn.europe-west1.gcp.commercetools.com/cffb5678-47af-495c-9f19-1c2ccfc5910c/51004692-Tonie_Shado-lr90t3Jb.png
+  image: https://images.cdn.europe-west1.gcp.commercetools.com/cffb5678-47af-495c-9f19-1c2ccfc5910c/51004692-Tonie_Shado-rQcPW0KO.png
   sample: https://cdn.tonies.de/o/audio_samples/a5dda0756597add52b9ccfe993a802251375c82ffa53dd6702a0e0e7/11000832_mini_loup_pirate_extraitmp3.mp3
   web: https://tonies.com/fr-fr/tonies/mini-loup/mini-loup-pirate/
   shop-id: c1d29abb-9aaf-4058-9473-70ed6c1ca2b8


### PR DESCRIPTION
There was an error in displaying the image on teddyCloud. Therefore I searched for the new image url and replaced it.
<img width="256" height="364" alt="image" src="https://github.com/user-attachments/assets/ffcf4b95-e229-4d0e-a921-26eb129208eb" />
