### PR TITLE
Add My First Tonies audio IDs for Bauernhof and Dschungel sets

### DIFF
--- a/yaml/11003558.yaml
+++ b/yaml/11003558.yaml
@@ -34,15 +34,15 @@ data:
   - audio-id: 1763982929
     hash: 2623b62e72075e1681b2e29fb55fa532a71ee1d3
     size: 9180083
-    tracks: 15
+    tracks: 5
     confidence: 0
   - audio-id: 1763982709
     hash: 5ba17f101f07340a1a88f0c5199e7415d4d6dd7f
     size: 8754934
-    tracks: 15
+    tracks: 5
     confidence: 0
   - audio-id: 1763981907
     hash: a44e5b228d2949fb3ae0d8036178ebcda9a65013
     size: 9197134
-    tracks: 15
+    tracks: 5
     confidence: 0

--- a/yaml/11003558.yaml
+++ b/yaml/11003558.yaml
@@ -30,4 +30,19 @@ data:
   - Tiger - Der Tiger und die Hummel
   - Tiger - Tiger schleichen durch den Dschungel (Klanglandschaft & Musik)
   - Tiger - Outro
-  ids: []
+  ids:
+  - audio-id: 1763982929
+    hash: 2623b62e72075e1681b2e29fb55fa532a71ee1d3
+    size: 9180083
+    tracks: 15
+    confidence: 0
+  - audio-id: 1763982709
+    hash: 5ba17f101f07340a1a88f0c5199e7415d4d6dd7f
+    size: 8754934
+    tracks: 15
+    confidence: 0
+  - audio-id: 1763981907
+    hash: a44e5b228d2949fb3ae0d8036178ebcda9a65013
+    size: 9197134
+    tracks: 15
+    confidence: 0

--- a/yaml/11003561.yaml
+++ b/yaml/11003561.yaml
@@ -34,15 +34,15 @@ data:
   - audio-id: 1763977309
     hash: cc80ab65f0534c5f20529f2ba3c777183443c956
     size: 8447066
-    tracks: 15
+    tracks: 5
     confidence: 0
   - audio-id: 1763979250
     hash: 4edaf9e962544c022611a8a739e1ae259f710a74
     size: 8995720
-    tracks: 15
+    tracks: 5
     confidence: 0
   - audio-id: 1763978986
     hash: 727907fc605b90f14f6ff8af19286cbe0517000a
     size: 8807957
-    tracks: 15
+    tracks: 5
     confidence: 0

--- a/yaml/11003561.yaml
+++ b/yaml/11003561.yaml
@@ -30,4 +30,19 @@ data:
   - Pferd - Mama Pferd und ihr Fohlen
   - Pferd - Pferde auf der Wiese (Klanglandschaft & Musik)
   - Pferd - Outro
-  ids: []
+  ids:
+  - audio-id: 1763977309
+    hash: cc80ab65f0534c5f20529f2ba3c777183443c956
+    size: 8447066
+    tracks: 15
+    confidence: 0
+  - audio-id: 1763979250
+    hash: 4edaf9e962544c022611a8a739e1ae259f710a74
+    size: 8995720
+    tracks: 15
+    confidence: 0
+  - audio-id: 1763978986
+    hash: 727907fc605b90f14f6ff8af19286cbe0517000a
+    size: 8807957
+    tracks: 15
+    confidence: 0


### PR DESCRIPTION
Adds missing `ids` blocks for two German My First Tonies sets:

* `11003558` — My First Tonies - Dschungel Set
* `11003561` — My First Tonies - Bauernhof Set

Added for each audio ID:

* `audio-id`
* SHA1 `hash`
* file `size`
* `tracks`
* `confidence: 0`

The values were extracted from local TeddyCloud `.taf` files.

Track counts were mapped from the existing `track-desc` groups in the YAML files:

* Dschungel Set: Affe, Papagei, Tiger — 5 tracks each
* Bauernhof Set: Schwein, Kuh, Pferd — 5 tracks each

Only the previously empty `ids: []` sections were changed.
