### PR TITLE
Add missing audio IDs for four French Tonies

### DIFF
--- a/yaml/10001016.yaml
+++ b/yaml/10001016.yaml
@@ -20,4 +20,9 @@ data:
   - 'Mes jeux sonores : les dinosaures'
   - Pourquoi chasse-t-on les astéroïdes ?
   - 'Mes jeux sonores : les astéroïdes'
-  ids: []
+  ids:
+  - audio-id: 1649077010
+    hash: c02a0f406e6a0001c3928dca55cabf7e7ef970c7
+    size: 45435391
+    tracks: 10
+    confidence: 0

--- a/yaml/10001262.yaml
+++ b/yaml/10001262.yaml
@@ -20,4 +20,9 @@ data:
   - 'Mes jeux sonores : la vie extraterrestres'
   - Vivre dans l'espace
   - 'Mes jeux sonores : la vie dans l''espace'
-  ids: []
+  ids:
+  - audio-id: 1649160719
+    hash: 8bd78769ed2b177d4934e710c63780ea2e94d806
+    size: 44688702
+    tracks: 10
+    confidence: 0

--- a/yaml/11000579.yaml
+++ b/yaml/11000579.yaml
@@ -24,4 +24,9 @@ data:
   - 'Académie des Dresseurs et Dresseuses : Les évolutions d’Évoli'
   - 'Histoire 3 : La tempête et le pique-nique'
   - Conclusion
-  ids: []
+  ids:
+  - audio-id: 1787090415
+    hash: bbb8ce600e531eb72cd439381c9800bf70bbf483
+    size: 58417018
+    tracks: 9
+    confidence: 0

--- a/yaml/11002167.yaml
+++ b/yaml/11002167.yaml
@@ -22,4 +22,9 @@ data:
   - Partie 2
   - 'Interlude : L''interview d''April'
   - Partie 3
-  ids: []
+  ids:
+  - audio-id: 1762169276
+    hash: e519d119f0162fed561703c7f99ed1719bd5a5fa
+    size: 35037124
+    tracks: 7
+    confidence: 0


### PR DESCRIPTION
## Summary

Adds missing audio identification data for four French Tonies whose product metadata already exists in the repository with empty `ids` arrays.

The values were extracted directly from genuine cached `.taf` files using teddyCloud's TAF metadata API. No existing product metadata, titles, track descriptions, URLs, or scraper-managed files are changed.

## Added IDs

| Article | Tonie | Audio ID | SHA-1 | Size | Tracks |
|---|---|---:|---|---:|---:|
| `10001016` | C'Est Toujours Pas Sorcier - Sur Les Traces Des Dinosaures | `1649077010` | `c02a0f406e6a0001c3928dca55cabf7e7ef970c7` | `45435391` | 10 |
| `10001262` | C'Est Toujours Pas Sorcier - Les Secrets De L'Espace | `1649160719` | `8bd78769ed2b177d4934e710c63780ea2e94d806` | `44688702` | 10 |
| `11000579` | Pokémon - Pikachu | `1787090415` | `bbb8ce600e531eb72cd439381c9800bf70bbf483` | `58417018` | 9 |
| `11002167` | Tortues Ninja - Leonardo | `1762169276` | `e519d119f0162fed561703c7f99ed1719bd5a5fa` | `35037124` | 7 |

All four entries use `confidence: 0` as manually observed TAF data, following the repository contribution guidance.

## Verification

- Audio IDs, SHA-1 hashes, sizes and track counts were read directly from teddyCloud.
- Each physical Tonie was matched to the existing French product record and official Tonies product page.
- All four target YAML records had `ids: []` before this change.
